### PR TITLE
test: add comprehensive unit coverage for release scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --runInBand
+
+      - name: Build action bundle
+        run: npm run build

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,0 +1,318 @@
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  setOutput: jest.fn(),
+  setFailed: jest.fn(),
+  getInput: jest.fn(),
+  getBooleanInput: jest.fn()
+}));
+
+jest.mock('@actions/github', () => ({
+  getOctokit: jest.fn(),
+  context: {
+    eventName: 'pull_request',
+    payload: { pull_request: { merged: true, labels: [] } },
+    ref: 'refs/heads/main',
+    repo: { owner: 'octocat', repo: 'demo-repo' }
+  }
+}));
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn()
+}));
+
+jest.mock('../src/utils', () => ({
+  detectTriggerMode: jest.fn(),
+  parseLabels: jest.fn()
+}));
+
+jest.mock('../src/version', () => ({
+  calculateVersion: jest.fn(),
+  updatePackageJson: jest.fn()
+}));
+
+jest.mock('../src/release', () => ({
+  createRelease: jest.fn(),
+  createMajorRelease: jest.fn()
+}));
+
+const core = require('@actions/core');
+const github = require('@actions/github');
+const { execSync } = require('child_process');
+const fs = require('fs');
+const utils = require('../src/utils');
+const version = require('../src/version');
+const release = require('../src/release');
+const { run } = require('../src/main');
+
+function setupCoreInputs(overrides = {}, booleanOverrides = {}) {
+  const stringInputs = {
+    'github-token': 'test-token',
+    'major-label': 'major',
+    'minor-label': 'minor',
+    'patch-label': 'patch',
+    'prerelease-label': 'prerelease',
+    'prerelease-suffix': 'beta',
+    'prerelease-number': '1',
+    'node-version': '20',
+    'package-manager': 'npm',
+    'working-directory': '.',
+    'install-command': 'npm ci',
+    'test-command': 'npm test',
+    'build-command': 'npm run build',
+    'package-json-path': 'package.json',
+    'git-user-name': 'github-actions[bot]',
+    'git-user-email': 'github-actions[bot]@users.noreply.github.com',
+    'trigger-mode': 'auto-detect',
+    ...overrides
+  };
+
+  const booleanInputs = {
+    'create-major-release': true,
+    'base_release': true,
+    'copy-assets': true,
+    'auto-generate-notes': true,
+    'update-package-json': true,
+    ...booleanOverrides
+  };
+
+  core.getInput.mockImplementation((name) => (name in stringInputs ? stringInputs[name] : ''));
+  core.getBooleanInput.mockImplementation((name) => !!booleanInputs[name]);
+}
+
+function setupFs({
+  packageJson = true,
+  actionYml = false,
+  actionYaml = false,
+  packageJsonContent = JSON.stringify({ scripts: { test: 'jest', build: 'ncc build src/main.js -o dist' } })
+} = {}) {
+  fs.existsSync.mockImplementation((filePath) => {
+    if (filePath === 'package.json') return packageJson;
+    if (filePath === 'action.yml') return actionYml;
+    if (filePath === 'action.yaml') return actionYaml;
+    return false;
+  });
+
+  fs.readFileSync.mockReturnValue(packageJsonContent);
+}
+
+function setupExecSync({
+  latestTags = 'v1.2.3\nv1',
+  commits = '- feat: add feature (abc123)',
+  throwOnFetch = false
+} = {}) {
+  execSync.mockImplementation((command) => {
+    if (command === 'git fetch --tags' && throwOnFetch) {
+      throw new Error('fetch failed');
+    }
+    if (command === 'git tag --sort=-version:refname') {
+      return latestTags;
+    }
+    if (command.startsWith('git log --pretty=format:"- %s (%h)"')) {
+      return commits;
+    }
+    if (command === 'git status --porcelain') {
+      return '';
+    }
+    return '';
+  });
+}
+
+describe('main.run', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    github.getOctokit.mockReturnValue({ rest: {} });
+    setupCoreInputs();
+    setupFs();
+    setupExecSync();
+  });
+
+  test('skips release when no release labels are resolved', async () => {
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'none', isPrerelease: false });
+
+    await run();
+
+    expect(core.setOutput).toHaveBeenCalledWith('released', 'false');
+    expect(core.setOutput).toHaveBeenCalledWith('release-type', 'none');
+    expect(version.calculateVersion).not.toHaveBeenCalled();
+    expect(release.createRelease).not.toHaveBeenCalled();
+  });
+
+  test('executes full stable release flow and creates major release', async () => {
+    setupCoreInputs({ 'working-directory': './project-dir' });
+    setupFs({ packageJson: true, actionYml: true });
+
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'minor', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.3.0');
+    release.createRelease.mockResolvedValue({
+      id: 99,
+      html_url: 'https://example.com/releases/v1.3.0',
+      name: 'v1.3.0',
+      body: 'Release body',
+      assets: []
+    });
+    release.createMajorRelease.mockResolvedValue({
+      html_url: 'https://example.com/releases/v1'
+    });
+
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+
+    await run();
+
+    expect(chdirSpy).toHaveBeenCalledWith('./project-dir');
+    expect(version.updatePackageJson).toHaveBeenCalledWith('package.json', 'v1.3.0');
+    expect(execSync).toHaveBeenCalledWith('npm ci', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith('npm test', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith('npm run build', { stdio: 'inherit' });
+    expect(release.createRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        tagName: 'v1.3.0',
+        name: 'v1.3.0',
+        prerelease: false
+      })
+    );
+    expect(release.createMajorRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        majorVersion: 'v1',
+        fullVersion: 'v1.3.0',
+        copyAssets: true
+      })
+    );
+    expect(core.setOutput).toHaveBeenCalledWith('released', 'true');
+    expect(core.setOutput).toHaveBeenCalledWith('version', 'v1.3.0');
+    expect(core.setOutput).toHaveBeenCalledWith('previous-version', 'v1.2.3');
+    expect(core.setOutput).toHaveBeenCalledWith('major-version', 'v1');
+    expect(core.setOutput).toHaveBeenCalledWith(
+      'major-release-url',
+      'https://example.com/releases/v1'
+    );
+
+    chdirSpy.mockRestore();
+  });
+
+  test('does not create major release for prereleases', async () => {
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: true });
+    version.calculateVersion.mockReturnValue('v1.2.4-beta.1');
+    release.createRelease.mockResolvedValue({
+      id: 100,
+      html_url: 'https://example.com/releases/v1.2.4-beta.1'
+    });
+
+    await run();
+
+    expect(release.createRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        tagName: 'v1.2.4-beta.1',
+        prerelease: true
+      })
+    );
+    expect(release.createMajorRelease).not.toHaveBeenCalled();
+    expect(core.setOutput).toHaveBeenCalledWith('is-prerelease', 'true');
+  });
+
+  test('uses plain release notes when auto-generate-notes is disabled', async () => {
+    setupCoreInputs({}, { 'auto-generate-notes': false });
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.2.4');
+    release.createRelease.mockResolvedValue({
+      id: 101,
+      html_url: 'https://example.com/releases/v1.2.4'
+    });
+    release.createMajorRelease.mockResolvedValue(null);
+
+    await run();
+
+    expect(release.createRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        body: 'Release v1.2.4'
+      })
+    );
+  });
+
+  test('falls back to v0.0.0 when tag discovery fails', async () => {
+    setupExecSync({ throwOnFetch: true });
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v0.0.1');
+    release.createRelease.mockResolvedValue({
+      id: 1,
+      html_url: 'https://example.com/releases/v0.0.1'
+    });
+    release.createMajorRelease.mockResolvedValue(null);
+
+    await run();
+
+    expect(core.setOutput).toHaveBeenCalledWith('previous-version', 'v0.0.0');
+    expect(release.createRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        body: expect.not.stringContaining('Full Changelog')
+      })
+    );
+  });
+
+  test('auto-detects install, test and build commands from package.json scripts', async () => {
+    setupCoreInputs({
+      'install-command': '',
+      'test-command': '',
+      'build-command': ''
+    });
+    setupFs({
+      packageJson: true,
+      actionYml: false,
+      packageJsonContent: JSON.stringify({
+        scripts: {
+          test: 'jest --coverage',
+          build: 'ncc build src/main.js -o dist'
+        }
+      })
+    });
+
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.2.4');
+    release.createRelease.mockResolvedValue({
+      id: 3,
+      html_url: 'https://example.com/releases/v1.2.4'
+    });
+    release.createMajorRelease.mockResolvedValue(null);
+
+    await run();
+
+    expect(execSync).toHaveBeenCalledWith('npm ci', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith('npm test', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith('npm run build', { stdio: 'inherit' });
+  });
+
+  test('marks action failed when an error bubbles up', async () => {
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.parseLabels.mockReturnValue({ releaseType: 'major', isPrerelease: false });
+    version.calculateVersion.mockImplementation(() => {
+      throw new Error('invalid release type');
+    });
+
+    await run();
+
+    expect(core.error).toHaveBeenCalledWith('❌ Action failed: invalid release type');
+    expect(core.setFailed).toHaveBeenCalledWith('invalid release type');
+  });
+});

--- a/__tests__/release.test.js
+++ b/__tests__/release.test.js
@@ -1,0 +1,430 @@
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+const core = require('@actions/core');
+const { execSync } = require('child_process');
+const {
+  createRelease,
+  createMajorRelease,
+  updateMajorVersionTag,
+  deleteMajorReleaseIfExists,
+  createMajorReleaseNotes,
+  copyReleaseAssets,
+  getReleaseByTag,
+  updateRelease
+} = require('../src/release');
+
+describe('release', () => {
+  const context = {
+    repo: {
+      owner: 'octocat',
+      repo: 'demo-repo'
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createRelease', () => {
+    test('creates a release and returns response data', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            createRelease: jest.fn().mockResolvedValue({
+              data: { id: 42, html_url: 'https://example.com/release/42' }
+            })
+          }
+        }
+      };
+
+      const release = await createRelease(octokit, context, {
+        tagName: 'v1.2.3',
+        name: 'v1.2.3',
+        body: 'notes',
+        prerelease: false
+      });
+
+      expect(octokit.rest.repos.createRelease).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'demo-repo',
+        tag_name: 'v1.2.3',
+        name: 'v1.2.3',
+        body: 'notes',
+        draft: false,
+        prerelease: false
+      });
+      expect(release).toEqual({ id: 42, html_url: 'https://example.com/release/42' });
+    });
+
+    test('logs and rethrows create release errors', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            createRelease: jest.fn().mockRejectedValue(new Error('API unavailable'))
+          }
+        }
+      };
+
+      await expect(
+        createRelease(octokit, context, {
+          tagName: 'v1.2.3',
+          name: 'v1.2.3',
+          body: 'notes'
+        })
+      ).rejects.toThrow('API unavailable');
+
+      expect(core.error).toHaveBeenCalledWith('Failed to create release: API unavailable');
+    });
+  });
+
+  describe('createMajorRelease', () => {
+    test('creates major release, updates tag and copies assets', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue({ status: 404 }),
+            createRelease: jest.fn().mockResolvedValue({
+              data: { id: 10, html_url: 'https://example.com/release/v1', draft: false }
+            }),
+            getReleaseAsset: jest.fn().mockResolvedValue({ data: Buffer.from('asset-bytes') }),
+            uploadReleaseAsset: jest.fn().mockResolvedValue({})
+          }
+        }
+      };
+
+      const originalRelease = {
+        name: 'v1.2.3',
+        body: 'Original notes',
+        assets: [{ id: 5, name: 'artifact.tgz', content_type: 'application/gzip', size: 11 }]
+      };
+
+      const result = await createMajorRelease(octokit, context, {
+        majorVersion: 'v1',
+        fullVersion: 'v1.2.3',
+        originalRelease,
+        copyAssets: true
+      });
+
+      expect(execSync).toHaveBeenCalledWith('git tag -a "v1" -m "Major version tag pointing to v1.2.3"');
+      expect(execSync).toHaveBeenCalledWith('git push origin "v1"');
+      expect(octokit.rest.repos.createRelease).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'demo-repo',
+        tag_name: 'v1',
+        name: 'v1',
+        body: expect.stringContaining('latest stable release: **v1.2.3**'),
+        draft: false,
+        prerelease: false,
+        make_latest: 'false'
+      });
+      expect(octokit.rest.repos.getReleaseAsset).toHaveBeenCalledTimes(1);
+      expect(octokit.rest.repos.uploadReleaseAsset).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ id: 10, html_url: 'https://example.com/release/v1', draft: false });
+    });
+
+    test('publishes major release explicitly if GitHub returns it as draft', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue({ status: 404 }),
+            createRelease: jest.fn().mockResolvedValue({
+              data: { id: 20, html_url: 'https://example.com/release/v2', draft: true }
+            }),
+            updateRelease: jest.fn().mockResolvedValue({ data: { id: 20, draft: false } })
+          }
+        }
+      };
+
+      const result = await createMajorRelease(octokit, context, {
+        majorVersion: 'v2',
+        fullVersion: 'v2.0.0',
+        originalRelease: { name: 'v2.0.0', body: 'notes', assets: [] },
+        copyAssets: false
+      });
+
+      expect(octokit.rest.repos.updateRelease).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'demo-repo',
+        release_id: 20,
+        draft: false
+      });
+      expect(result.id).toBe(20);
+    });
+
+    test('returns null when major release flow fails', async () => {
+      execSync.mockImplementation((command) => {
+        if (command.startsWith('git tag -a')) {
+          throw new Error('Cannot create tag');
+        }
+        return '';
+      });
+
+      const octokit = {
+        rest: {
+          repos: {
+            createRelease: jest.fn()
+          }
+        }
+      };
+
+      const result = await createMajorRelease(octokit, context, {
+        majorVersion: 'v3',
+        fullVersion: 'v3.0.0',
+        originalRelease: { name: 'v3.0.0', body: 'notes', assets: [] },
+        copyAssets: false
+      });
+
+      expect(result).toBeNull();
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to create major version release: Cannot create tag')
+      );
+    });
+  });
+
+  describe('updateMajorVersionTag', () => {
+    test('handles missing old tags and pushes new major tag', async () => {
+      execSync.mockImplementation((command) => {
+        if (command.startsWith('git tag -d')) {
+          throw new Error('local tag missing');
+        }
+        if (command.startsWith('git push origin ":refs/tags/')) {
+          throw new Error('remote tag missing');
+        }
+        return '';
+      });
+
+      await expect(updateMajorVersionTag('v1', 'v1.2.3')).resolves.toBeUndefined();
+
+      expect(execSync).toHaveBeenCalledWith('git tag -a "v1" -m "Major version tag pointing to v1.2.3"');
+      expect(execSync).toHaveBeenCalledWith('git push origin "v1"');
+    });
+
+    test('throws when creating new major tag fails', async () => {
+      execSync.mockImplementation((command) => {
+        if (command.startsWith('git tag -a')) {
+          throw new Error('tag creation failed');
+        }
+        return '';
+      });
+
+      await expect(updateMajorVersionTag('v9', 'v9.0.0')).rejects.toThrow('tag creation failed');
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update major version tag: tag creation failed')
+      );
+    });
+  });
+
+  describe('deleteMajorReleaseIfExists', () => {
+    test('deletes existing major release', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockResolvedValue({ data: { id: 321 } }),
+            deleteRelease: jest.fn().mockResolvedValue({})
+          }
+        }
+      };
+
+      await deleteMajorReleaseIfExists(octokit, context, 'v1');
+
+      expect(octokit.rest.repos.deleteRelease).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'demo-repo',
+        release_id: 321
+      });
+    });
+
+    test('logs info when major release does not exist', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue({ status: 404 })
+          }
+        }
+      };
+
+      await deleteMajorReleaseIfExists(octokit, context, 'v1');
+
+      expect(core.info).toHaveBeenCalledWith("Major release v1 doesn't exist, creating new one");
+    });
+
+    test('logs warning on non-404 errors', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue({ status: 500, message: 'Internal API error' })
+          }
+        }
+      };
+
+      await deleteMajorReleaseIfExists(octokit, context, 'v1');
+
+      expect(core.warning).toHaveBeenCalledWith(
+        'Error checking for existing major release: Internal API error'
+      );
+    });
+  });
+
+  describe('createMajorReleaseNotes', () => {
+    test('builds a major release note body from original release', () => {
+      const notes = createMajorReleaseNotes('v4', 'v4.5.6', {
+        name: 'v4.5.6',
+        body: 'Original release notes'
+      });
+
+      expect(notes).toContain('# v4');
+      expect(notes).toContain('**v4.5.6**');
+      expect(notes).toContain('## Latest Release: v4.5.6');
+      expect(notes).toContain('Original release notes');
+    });
+  });
+
+  describe('copyReleaseAssets', () => {
+    test('returns early when there are no assets', async () => {
+      const octokit = {
+        rest: { repos: {} }
+      };
+
+      await copyReleaseAssets(
+        octokit,
+        context,
+        { assets: [] },
+        { id: 100 }
+      );
+
+      expect(core.info).toHaveBeenCalledWith('No assets to copy from source release');
+    });
+
+    test('copies assets and continues when one asset fails', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseAsset: jest
+              .fn()
+              .mockResolvedValueOnce({ data: Buffer.from('asset1') })
+              .mockRejectedValueOnce(new Error('download failed')),
+            uploadReleaseAsset: jest.fn().mockResolvedValue({})
+          }
+        }
+      };
+
+      const sourceRelease = {
+        assets: [
+          { id: 1, name: 'ok.txt', content_type: 'text/plain', size: 3 },
+          { id: 2, name: 'broken.txt', content_type: 'text/plain', size: 5 }
+        ]
+      };
+
+      await copyReleaseAssets(octokit, context, sourceRelease, { id: 77 });
+
+      expect(octokit.rest.repos.uploadReleaseAsset).toHaveBeenCalledTimes(1);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to copy asset broken.txt: download failed')
+      );
+    });
+
+    test('logs warning on top-level copy errors', async () => {
+      const octokit = { rest: { repos: {} } };
+      await copyReleaseAssets(octokit, context, null, { id: 1 });
+
+      expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Failed to copy release assets:'));
+    });
+  });
+
+  describe('getReleaseByTag', () => {
+    test('returns release data when found', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockResolvedValue({ data: { id: 1, tag_name: 'v1.0.0' } })
+          }
+        }
+      };
+
+      await expect(getReleaseByTag(octokit, context, 'v1.0.0')).resolves.toEqual({
+        id: 1,
+        tag_name: 'v1.0.0'
+      });
+    });
+
+    test('returns null when release is not found', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue({ status: 404 })
+          }
+        }
+      };
+
+      await expect(getReleaseByTag(octokit, context, 'v1.0.0')).resolves.toBeNull();
+    });
+
+    test('rethrows non-404 errors', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            getReleaseByTag: jest.fn().mockRejectedValue(new Error('network down'))
+          }
+        }
+      };
+
+      await expect(getReleaseByTag(octokit, context, 'v1.0.0')).rejects.toThrow('network down');
+    });
+  });
+
+  describe('updateRelease', () => {
+    test('updates release and returns response data', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            updateRelease: jest.fn().mockResolvedValue({ data: { id: 2, name: 'v1' } })
+          }
+        }
+      };
+
+      const updated = await updateRelease(octokit, context, 2, {
+        name: 'v1',
+        body: 'updated',
+        prerelease: false
+      });
+
+      expect(octokit.rest.repos.updateRelease).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'demo-repo',
+        release_id: 2,
+        name: 'v1',
+        body: 'updated',
+        prerelease: false
+      });
+      expect(updated).toEqual({ id: 2, name: 'v1' });
+    });
+
+    test('logs and rethrows update errors', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            updateRelease: jest.fn().mockRejectedValue(new Error('cannot update'))
+          }
+        }
+      };
+
+      await expect(
+        updateRelease(octokit, context, 2, {
+          name: 'v1',
+          body: 'updated',
+          prerelease: false
+        })
+      ).rejects.toThrow('cannot update');
+
+      expect(core.error).toHaveBeenCalledWith('Failed to update release: cannot update');
+    });
+  });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,10 +1,145 @@
-const { parseVersion, formatVersion, detectTriggerMode } = require('../src/utils');
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  getInput: jest.fn(),
+  getBooleanInput: jest.fn()
+}));
 
-describe('Utils', () => {
+jest.mock('@actions/github', () => ({}));
+
+const core = require('@actions/core');
+const {
+  detectTriggerMode,
+  parseLabels,
+  parseVersion,
+  formatVersion,
+  validateInputs,
+  sleep
+} = require('../src/utils');
+
+describe('utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('detectTriggerMode', () => {
+    test('returns explicit mode when auto-detect is not used', () => {
+      const context = { eventName: 'pull_request' };
+      expect(detectTriggerMode('workflow-call', context)).toBe('workflow-call');
+    });
+
+    test('detects PR merge', () => {
+      const context = {
+        eventName: 'pull_request',
+        payload: { pull_request: { merged: true } }
+      };
+      expect(detectTriggerMode('auto-detect', context)).toBe('pr-merge');
+    });
+
+    test('detects manual trigger', () => {
+      expect(detectTriggerMode('auto-detect', { eventName: 'workflow_dispatch' })).toBe('manual');
+    });
+
+    test('detects workflow_call trigger', () => {
+      expect(detectTriggerMode('auto-detect', { eventName: 'workflow_call' })).toBe('workflow-call');
+    });
+
+    test('detects push to main', () => {
+      const context = { eventName: 'push', ref: 'refs/heads/main' };
+      expect(detectTriggerMode('auto-detect', context)).toBe('push-main');
+    });
+
+    test('returns unknown for unsupported events', () => {
+      expect(detectTriggerMode('auto-detect', { eventName: 'schedule' })).toBe('unknown');
+    });
+  });
+
+  describe('parseLabels', () => {
+    const labelInputs = {
+      majorLabel: 'major',
+      minorLabel: 'minor',
+      patchLabel: 'patch',
+      prereleaseLabel: 'prerelease'
+    };
+
+    test('parses PR labels and applies major > minor > patch precedence', () => {
+      const context = {
+        payload: {
+          pull_request: {
+            labels: [{ name: 'patch' }, { name: 'minor' }, { name: 'major' }, { name: 'prerelease' }]
+          }
+        }
+      };
+
+      expect(parseLabels(context, labelInputs, 'pr-merge')).toEqual({
+        releaseType: 'major',
+        isPrerelease: true
+      });
+      expect(core.info).toHaveBeenCalledWith('PR labels: patch, minor, major, prerelease');
+    });
+
+    test('returns none when PR has no release labels', () => {
+      const context = { payload: { pull_request: { labels: [{ name: 'docs' }] } } };
+      expect(parseLabels(context, labelInputs, 'pr-merge')).toEqual({
+        releaseType: 'none',
+        isPrerelease: false
+      });
+    });
+
+    test('supports prerelease-only PR labels', () => {
+      const context = { payload: { pull_request: { labels: [{ name: 'prerelease' }] } } };
+      expect(parseLabels(context, labelInputs, 'pr-merge')).toEqual({
+        releaseType: 'none',
+        isPrerelease: true
+      });
+    });
+
+    test('reads manual trigger inputs', () => {
+      core.getInput.mockReturnValue('minor');
+      core.getBooleanInput.mockReturnValue(true);
+
+      expect(parseLabels({}, labelInputs, 'manual')).toEqual({
+        releaseType: 'minor',
+        isPrerelease: true
+      });
+      expect(core.getInput).toHaveBeenCalledWith('manual-release-type');
+      expect(core.getBooleanInput).toHaveBeenCalledWith('manual-is-prerelease');
+    });
+
+    test('uses manual defaults when manual inputs are not set', () => {
+      core.getInput.mockReturnValue('');
+      core.getBooleanInput.mockReturnValue(false);
+
+      expect(parseLabels({}, labelInputs, 'manual')).toEqual({
+        releaseType: 'patch',
+        isPrerelease: false
+      });
+    });
+
+    test('reads workflow-call inputs', () => {
+      core.getInput.mockReturnValue('major');
+      core.getBooleanInput.mockReturnValue(true);
+
+      expect(parseLabels({}, labelInputs, 'workflow-call')).toEqual({
+        releaseType: 'major',
+        isPrerelease: true
+      });
+      expect(core.getInput).toHaveBeenCalledWith('release-type');
+      expect(core.getBooleanInput).toHaveBeenCalledWith('is-prerelease');
+    });
+
+    test('returns defaults for unknown trigger modes', () => {
+      expect(parseLabels({}, labelInputs, 'unknown')).toEqual({
+        releaseType: 'none',
+        isPrerelease: false
+      });
+    });
+  });
+
   describe('parseVersion', () => {
     test('parses standard version', () => {
-      const result = parseVersion('v1.2.3');
-      expect(result).toEqual({
+      expect(parseVersion('v1.2.3')).toEqual({
         major: 1,
         minor: 2,
         patch: 3,
@@ -12,43 +147,71 @@ describe('Utils', () => {
       });
     });
 
+    test('parses version without v prefix', () => {
+      expect(parseVersion('2.5.9')).toEqual({
+        major: 2,
+        minor: 5,
+        patch: 9,
+        prerelease: null
+      });
+    });
+
     test('parses prerelease version', () => {
-      const result = parseVersion('v1.2.3-beta.1');
-      expect(result).toEqual({
+      expect(parseVersion('v1.2.3-beta.1')).toEqual({
         major: 1,
         minor: 2,
         patch: 3,
         prerelease: 'beta.1'
       });
     });
+
+    test('fills missing version segments with zero', () => {
+      expect(parseVersion('v7.1')).toEqual({
+        major: 7,
+        minor: 1,
+        patch: 0,
+        prerelease: null
+      });
+    });
   });
 
   describe('formatVersion', () => {
     test('formats standard version', () => {
-      const result = formatVersion(1, 2, 3);
-      expect(result).toBe('v1.2.3');
+      expect(formatVersion(1, 2, 3)).toBe('v1.2.3');
     });
 
     test('formats prerelease version', () => {
-      const result = formatVersion(1, 2, 3, 'beta.1');
-      expect(result).toBe('v1.2.3-beta.1');
+      expect(formatVersion(1, 2, 3, 'beta.1')).toBe('v1.2.3-beta.1');
     });
   });
 
-  describe('detectTriggerMode', () => {
-    test('detects PR merge', () => {
-      const context = {
-        eventName: 'pull_request',
-        payload: { pull_request: { merged: true } }
-      };
-      const result = detectTriggerMode('auto-detect', context);
-      expect(result).toBe('pr-merge');
+  describe('validateInputs', () => {
+    test('accepts valid input values', () => {
+      expect(() => validateInputs({ githubToken: 'token', packageManager: 'npm' })).not.toThrow();
     });
 
-    test('detects manual trigger', () => {
-      const context = { eventName: 'workflow_dispatch' };
-      const result = detectTriggerMode('auto-detect', context);
-      expect(result).toBe('manual');
+    test('rejects missing github token', () => {
+      expect(() => validateInputs({ githubToken: '', packageManager: 'npm' })).toThrow(
+        'Invalid inputs: github-token is required'
+      );
+    });
+
+    test('rejects invalid package manager', () => {
+      expect(() => validateInputs({ githubToken: 'token', packageManager: 'pip' })).toThrow(
+        'Invalid inputs: package-manager must be one of: npm, yarn, pnpm'
+      );
+    });
+
+    test('returns all input validation errors', () => {
+      expect(() => validateInputs({ githubToken: '', packageManager: 'pip' })).toThrow(
+        'Invalid inputs: github-token is required, package-manager must be one of: npm, yarn, pnpm'
+      );
+    });
+  });
+
+  describe('sleep', () => {
+    test('resolves after waiting', async () => {
+      await expect(sleep(0)).resolves.toBeUndefined();
     });
   });
 });

--- a/__tests__/version.test.js
+++ b/__tests__/version.test.js
@@ -1,0 +1,172 @@
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn()
+}));
+
+const core = require('@actions/core');
+const fs = require('fs');
+const {
+  calculateVersion,
+  updatePackageJson,
+  parseExistingPrerelease,
+  incrementPrerelease,
+  validateVersion,
+  compareVersions
+} = require('../src/version');
+
+describe('version', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('calculateVersion', () => {
+    const prereleaseInputs = { prereleaseSuffix: 'beta', prereleaseNumber: '1' };
+
+    test('calculates major release', () => {
+      expect(calculateVersion('v1.2.3', 'major', false, prereleaseInputs)).toBe('v2.0.0');
+    });
+
+    test('calculates minor release', () => {
+      expect(calculateVersion('v1.2.3', 'minor', false, prereleaseInputs)).toBe('v1.3.0');
+    });
+
+    test('calculates patch release', () => {
+      expect(calculateVersion('v1.2.3', 'patch', false, prereleaseInputs)).toBe('v1.2.4');
+    });
+
+    test('adds prerelease suffix when requested', () => {
+      expect(calculateVersion('v1.2.3', 'minor', true, prereleaseInputs)).toBe('v1.3.0-beta.1');
+    });
+
+    test('throws for invalid release type', () => {
+      expect(() => calculateVersion('v1.2.3', 'invalid', false, prereleaseInputs)).toThrow(
+        'Invalid release type: invalid'
+      );
+    });
+  });
+
+  describe('updatePackageJson', () => {
+    test('skips update when file does not exist', () => {
+      fs.existsSync.mockReturnValue(false);
+
+      updatePackageJson('package.json', 'v1.2.3');
+
+      expect(core.warning).toHaveBeenCalledWith(
+        'Package.json not found at package.json, skipping version update'
+      );
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    test('updates package.json version and strips v prefix', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue(JSON.stringify({ name: 'demo', version: '0.1.0' }));
+
+      updatePackageJson('package.json', 'v1.2.3');
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        'package.json',
+        expect.stringContaining('"version": "1.2.3"')
+      );
+      expect(core.info).toHaveBeenCalledWith('✅ Updated package.json version to 1.2.3');
+    });
+
+    test('logs warning when package.json cannot be parsed', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue('{');
+
+      updatePackageJson('package.json', 'v1.2.3');
+
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update package.json:')
+      );
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parseExistingPrerelease', () => {
+    test('parses prerelease suffix and number', () => {
+      expect(parseExistingPrerelease('v1.2.3-beta.10')).toEqual({
+        suffix: 'beta',
+        number: 10
+      });
+    });
+
+    test('returns null for non-prerelease version', () => {
+      expect(parseExistingPrerelease('v1.2.3')).toBeNull();
+    });
+
+    test('returns null for unsupported prerelease format', () => {
+      expect(parseExistingPrerelease('v1.2.3-beta')).toBeNull();
+    });
+  });
+
+  describe('incrementPrerelease', () => {
+    test('increments existing prerelease number when suffix matches', () => {
+      const result = incrementPrerelease('v1.2.3-beta.2', {
+        prereleaseSuffix: 'beta',
+        prereleaseNumber: '1'
+      });
+      expect(result).toBe('v1.2.3-beta.3');
+    });
+
+    test('restarts prerelease when suffix differs', () => {
+      const result = incrementPrerelease('v1.2.3-alpha.5', {
+        prereleaseSuffix: 'beta',
+        prereleaseNumber: '1'
+      });
+      expect(result).toBe('v1.2.3-alpha.5-beta.1');
+    });
+
+    test('starts prerelease when none exists', () => {
+      const result = incrementPrerelease('v1.2.3', {
+        prereleaseSuffix: 'rc',
+        prereleaseNumber: '4'
+      });
+      expect(result).toBe('v1.2.3-rc.4');
+    });
+  });
+
+  describe('validateVersion', () => {
+    test('accepts valid stable versions', () => {
+      expect(() => validateVersion('v1.2.3')).not.toThrow();
+      expect(() => validateVersion('1.2.3')).not.toThrow();
+    });
+
+    test('accepts valid prerelease versions', () => {
+      expect(() => validateVersion('v1.2.3-beta.1')).not.toThrow();
+    });
+
+    test('rejects invalid versions', () => {
+      expect(() => validateVersion('1.2')).toThrow('Invalid version format: 1.2');
+      expect(() => validateVersion('v1.2.3-beta')).toThrow('Invalid version format: v1.2.3-beta');
+    });
+  });
+
+  describe('compareVersions', () => {
+    test('compares major, minor and patch components', () => {
+      expect(compareVersions('v2.0.0', 'v1.9.9')).toBeGreaterThan(0);
+      expect(compareVersions('v1.5.0', 'v1.4.9')).toBeGreaterThan(0);
+      expect(compareVersions('v1.4.2', 'v1.4.3')).toBeLessThan(0);
+    });
+
+    test('treats prerelease as lower than stable', () => {
+      expect(compareVersions('v1.0.0-beta.1', 'v1.0.0')).toBeLessThan(0);
+      expect(compareVersions('v1.0.0', 'v1.0.0-beta.1')).toBeGreaterThan(0);
+    });
+
+    test('compares prerelease strings lexicographically', () => {
+      expect(compareVersions('v1.0.0-alpha.1', 'v1.0.0-beta.1')).toBeLessThan(0);
+    });
+
+    test('returns zero for equal versions', () => {
+      expect(compareVersions('v1.2.3', 'v1.2.3')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expand utils unit tests to cover trigger detection, label parsing, validation, parsing/formatting and sleep behavior
- add version unit tests for bump logic, prerelease helpers, package.json updates, validation and version comparison
- add release unit tests for release/major-release API interactions, tag updates, deletion checks, note generation and asset copying
- add main orchestration tests covering skip/success/prerelease/failure flows and command auto-detection

## Validation
- npm test -- --runInBand
- npm test -- --coverage --runInBand

## Coverage
- statements: 94.84%
- branches: 87.19%
- functions: 100%
- lines: 94.79%