### PR TITLE
chore: upgrade action and workflows to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When you merge a PR with labels, the action automatically:
     prerelease-number: '1'
     
     # Build configuration
-    node-version: '20'
+    node-version: '24'
     package-manager: 'npm'  # npm, yarn, pnpm
     working-directory: '.'
     

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
   node-version:
     description: 'Node.js version to use for building'
     required: false
-    default: '20'
+    default: '24'
   package-manager:
     description: 'Package manager to use (npm, yarn, pnpm)'
     required: false
@@ -134,5 +134,5 @@ outputs:
     description: 'Git tag name that was created'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- upgrade action runtime from node20 to node24
- update default node-version input from 20 to 24
- update CI/release/manual-release workflows to setup Node.js 24
- update README example config to node-version 24

## Validation
- npm test -- --runInBand
- npm run build