### PR TITLE
[codex] Support protected-branch release validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A powerful GitHub Action that automates semantic versioning and release creation
 
 - 🏷️ **Label-based releases** - Control versions with simple PR labels
 - 📦 **Semantic versioning** - Automatic major/minor/patch version calculation
+- 🔒 **Protected-branch friendly** - Validate `package.json` in PRs and release on merge without pushing back to `main`
 - 🚀 **Prerelease support** - Create beta/alpha/rc releases
 - 🔄 **Major version tracking** - Automatic v1, v2, etc. release management
 - 📝 **Auto-generated notes** - Release notes from commit history
@@ -86,6 +87,73 @@ When you merge a PR with labels, the action automatically:
 - Generates release notes from commits
 - **With `base_release: true`**: Updates major version tags (v1, v2, etc.) to the latest release without creating a second major-tag release entry
 
+## 🔒 Protected Branches
+
+If `main` is protected, the safest pattern is:
+
+1. Validate the expected version on every PR.
+2. Require `package.json` to already contain that version before merge.
+3. Create the tag and GitHub release after merge without pushing a new commit back to `main`.
+
+This avoids branch-protection conflicts and prevents accidental double bumps. The version is always recalculated from the latest real tag plus the current PR labels, so changing labels ten times on the same PR does not increment ten times.
+
+### PR Validation Workflow
+
+```yaml
+name: Version Check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dnogu/semantic-release-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          execution-mode: validate
+          package-json-mode: verify
+```
+
+### Merge Release Workflow
+
+```yaml
+name: Release
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dnogu/semantic-release-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          execution-mode: release
+          package-json-mode: verify
+          commit-changes: false
+          base_release: true
+```
+
+With this setup, the merged `package.json` version must already match the tag that gets created by the release job.
+
 ## 📚 Full Configuration
 
 ```yaml
@@ -121,12 +189,17 @@ When you merge a PR with labels, the action automatically:
     auto-generate-notes: true
     
     # Package.json handling
-    update-package-json: true
+    update-package-json: true      # legacy toggle
+    package-json-mode: 'update'    # update, verify, ignore
     package-json-path: 'package.json'
     
     # Git configuration
     git-user-name: 'github-actions[bot]'
     git-user-email: 'github-actions[bot]@users.noreply.github.com'
+
+    # Release execution
+    commit-changes: true           # set false for protected branches
+    execution-mode: 'auto-detect'  # auto-detect, validate, release
 ```
 
 ## 📤 Outputs
@@ -179,7 +252,7 @@ The action provides useful outputs for downstream jobs:
 - uses: dnogu/semantic-release-action@v1
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-    update-package-json: false
+    package-json-mode: ignore
     test-command: 'python -m pytest'
     build-command: 'python setup.py build'
 ```
@@ -218,6 +291,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           release-type: ${{ github.event.inputs.release-type }}
           is-prerelease: ${{ github.event.inputs.is-prerelease }}
+```
+
+### Scenario 5: Protected Branches
+
+```yaml
+- uses: dnogu/semantic-release-action@v1
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    execution-mode: release
+    package-json-mode: verify
+    commit-changes: false
 ```
 
 ## 🔧 Advanced Features

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -29,12 +29,14 @@ jest.mock('fs', () => ({
 
 jest.mock('../src/utils', () => ({
   detectTriggerMode: jest.fn(),
+  detectExecutionMode: jest.fn(),
   parseLabels: jest.fn()
 }));
 
 jest.mock('../src/version', () => ({
   calculateVersion: jest.fn(),
-  updatePackageJson: jest.fn()
+  updatePackageJson: jest.fn(),
+  verifyPackageJsonVersion: jest.fn()
 }));
 
 jest.mock('../src/release', () => ({
@@ -66,10 +68,12 @@ function setupCoreInputs(overrides = {}, booleanOverrides = {}) {
     'install-command': 'npm ci',
     'test-command': 'npm test',
     'build-command': 'npm run build',
+    'package-json-mode': 'update',
     'package-json-path': 'package.json',
     'git-user-name': 'github-actions[bot]',
     'git-user-email': 'github-actions[bot]@users.noreply.github.com',
     'trigger-mode': 'auto-detect',
+    'execution-mode': 'auto-detect',
     ...overrides
   };
 
@@ -79,6 +83,7 @@ function setupCoreInputs(overrides = {}, booleanOverrides = {}) {
     'copy-assets': true,
     'auto-generate-notes': true,
     'update-package-json': true,
+    'commit-changes': true,
     ...booleanOverrides
   };
 
@@ -131,6 +136,7 @@ describe('main.run', () => {
     setupCoreInputs();
     setupFs();
     setupExecSync();
+    utils.detectExecutionMode.mockReturnValue('release');
   });
 
   test('skips release when no release labels are resolved', async () => {
@@ -197,6 +203,49 @@ describe('main.run', () => {
     );
 
     chdirSpy.mockRestore();
+  });
+
+  test('validates planned version for open PRs without creating a release', async () => {
+    setupCoreInputs({ 'package-json-mode': 'verify' });
+
+    utils.detectTriggerMode.mockReturnValue('pr-open');
+    utils.detectExecutionMode.mockReturnValue('validate');
+    utils.parseLabels.mockReturnValue({ releaseType: 'minor', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.3.0');
+
+    await run();
+
+    expect(version.verifyPackageJsonVersion).toHaveBeenCalledWith('package.json', 'v1.3.0');
+    expect(version.updatePackageJson).not.toHaveBeenCalled();
+    expect(release.createRelease).not.toHaveBeenCalled();
+    expect(execSync).not.toHaveBeenCalledWith('npm ci', { stdio: 'inherit' });
+    expect(core.setOutput).toHaveBeenCalledWith('released', 'false');
+    expect(core.setOutput).toHaveBeenCalledWith('version', 'v1.3.0');
+  });
+
+  test('can verify package.json and create a tag without pushing the branch', async () => {
+    setupCoreInputs(
+      { 'package-json-mode': 'verify' },
+      { 'commit-changes': false }
+    );
+    setupFs({ packageJson: true, actionYml: true });
+
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.detectExecutionMode.mockReturnValue('release');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.2.4');
+    release.createRelease.mockResolvedValue({
+      id: 102,
+      html_url: 'https://example.com/releases/v1.2.4'
+    });
+    release.createMajorRelease.mockResolvedValue(null);
+
+    await run();
+
+    expect(version.verifyPackageJsonVersion).toHaveBeenCalledWith('package.json', 'v1.2.4');
+    expect(version.updatePackageJson).not.toHaveBeenCalled();
+    expect(execSync).not.toHaveBeenCalledWith('git push origin HEAD');
+    expect(execSync).toHaveBeenCalledWith('git push origin "v1.2.4"');
   });
 
   test('does not create major release for prereleases', async () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -11,6 +11,7 @@ jest.mock('@actions/github', () => ({}));
 const core = require('@actions/core');
 const {
   detectTriggerMode,
+  detectExecutionMode,
   parseLabels,
   parseVersion,
   formatVersion,
@@ -37,6 +38,14 @@ describe('utils', () => {
       expect(detectTriggerMode('auto-detect', context)).toBe('pr-merge');
     });
 
+    test('detects open PR events', () => {
+      const context = {
+        eventName: 'pull_request',
+        payload: { pull_request: { merged: false } }
+      };
+      expect(detectTriggerMode('auto-detect', context)).toBe('pr-open');
+    });
+
     test('detects manual trigger', () => {
       expect(detectTriggerMode('auto-detect', { eventName: 'workflow_dispatch' })).toBe('manual');
     });
@@ -52,6 +61,21 @@ describe('utils', () => {
 
     test('returns unknown for unsupported events', () => {
       expect(detectTriggerMode('auto-detect', { eventName: 'schedule' })).toBe('unknown');
+    });
+  });
+
+  describe('detectExecutionMode', () => {
+    test('returns explicit mode when auto-detect is not used', () => {
+      expect(detectExecutionMode('release', 'pr-open')).toBe('release');
+    });
+
+    test('uses validate mode for open PRs', () => {
+      expect(detectExecutionMode('auto-detect', 'pr-open')).toBe('validate');
+    });
+
+    test('uses release mode for merged PRs and other triggers', () => {
+      expect(detectExecutionMode('auto-detect', 'pr-merge')).toBe('release');
+      expect(detectExecutionMode('auto-detect', 'workflow-call')).toBe('release');
     });
   });
 
@@ -187,24 +211,78 @@ describe('utils', () => {
 
   describe('validateInputs', () => {
     test('accepts valid input values', () => {
-      expect(() => validateInputs({ githubToken: 'token', packageManager: 'npm' })).not.toThrow();
+      expect(() =>
+        validateInputs({
+          githubToken: 'token',
+          packageManager: 'npm',
+          executionMode: 'auto-detect',
+          packageJsonMode: 'update'
+        })
+      ).not.toThrow();
     });
 
     test('rejects missing github token', () => {
-      expect(() => validateInputs({ githubToken: '', packageManager: 'npm' })).toThrow(
+      expect(() =>
+        validateInputs({
+          githubToken: '',
+          packageManager: 'npm',
+          executionMode: 'auto-detect',
+          packageJsonMode: 'update'
+        })
+      ).toThrow(
         'Invalid inputs: github-token is required'
       );
     });
 
     test('rejects invalid package manager', () => {
-      expect(() => validateInputs({ githubToken: 'token', packageManager: 'pip' })).toThrow(
+      expect(() =>
+        validateInputs({
+          githubToken: 'token',
+          packageManager: 'pip',
+          executionMode: 'auto-detect',
+          packageJsonMode: 'update'
+        })
+      ).toThrow(
         'Invalid inputs: package-manager must be one of: npm, yarn, pnpm'
       );
     });
 
+    test('rejects invalid execution mode', () => {
+      expect(() =>
+        validateInputs({
+          githubToken: 'token',
+          packageManager: 'npm',
+          executionMode: 'preview',
+          packageJsonMode: 'update'
+        })
+      ).toThrow(
+        'Invalid inputs: execution-mode must be one of: auto-detect, validate, release'
+      );
+    });
+
+    test('rejects invalid package.json mode', () => {
+      expect(() =>
+        validateInputs({
+          githubToken: 'token',
+          packageManager: 'npm',
+          executionMode: 'auto-detect',
+          packageJsonMode: 'sync'
+        })
+      ).toThrow(
+        'Invalid inputs: package-json-mode must be one of: update, verify, ignore'
+      );
+    });
+
     test('returns all input validation errors', () => {
-      expect(() => validateInputs({ githubToken: '', packageManager: 'pip' })).toThrow(
-        'Invalid inputs: github-token is required, package-manager must be one of: npm, yarn, pnpm'
+      expect(() =>
+        validateInputs({
+          githubToken: '',
+          packageManager: 'pip',
+          executionMode: 'preview',
+          packageJsonMode: 'sync'
+        })
+      ).toThrow(
+        'Invalid inputs: github-token is required, package-manager must be one of: npm, yarn, pnpm, execution-mode must be one of: auto-detect, validate, release, package-json-mode must be one of: update, verify, ignore'
       );
     });
   });

--- a/__tests__/version.test.js
+++ b/__tests__/version.test.js
@@ -15,6 +15,7 @@ const fs = require('fs');
 const {
   calculateVersion,
   updatePackageJson,
+  verifyPackageJsonVersion,
   parseExistingPrerelease,
   incrementPrerelease,
   validateVersion,
@@ -56,7 +57,7 @@ describe('version', () => {
     test('skips update when file does not exist', () => {
       fs.existsSync.mockReturnValue(false);
 
-      updatePackageJson('package.json', 'v1.2.3');
+      expect(updatePackageJson('package.json', 'v1.2.3')).toBe(false);
 
       expect(core.warning).toHaveBeenCalledWith(
         'Package.json not found at package.json, skipping version update'
@@ -68,7 +69,7 @@ describe('version', () => {
       fs.existsSync.mockReturnValue(true);
       fs.readFileSync.mockReturnValue(JSON.stringify({ name: 'demo', version: '0.1.0' }));
 
-      updatePackageJson('package.json', 'v1.2.3');
+      expect(updatePackageJson('package.json', 'v1.2.3')).toBe(true);
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         'package.json',
@@ -81,12 +82,45 @@ describe('version', () => {
       fs.existsSync.mockReturnValue(true);
       fs.readFileSync.mockReturnValue('{');
 
-      updatePackageJson('package.json', 'v1.2.3');
+      expect(updatePackageJson('package.json', 'v1.2.3')).toBe(false);
 
       expect(core.warning).toHaveBeenCalledWith(
         expect.stringContaining('Failed to update package.json:')
       );
       expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyPackageJsonVersion', () => {
+    test('skips verification when file does not exist', () => {
+      fs.existsSync.mockReturnValue(false);
+
+      expect(verifyPackageJsonVersion('package.json', 'v1.2.3')).toBe(false);
+      expect(core.warning).toHaveBeenCalledWith(
+        'Package.json not found at package.json, skipping version verification'
+      );
+    });
+
+    test('passes when package.json version matches expected tag', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: '1.2.3' }));
+
+      expect(verifyPackageJsonVersion('package.json', 'v1.2.3')).toBe(true);
+      expect(core.info).toHaveBeenCalledWith(
+        '✅ Verified package.json version matches 1.2.3'
+      );
+    });
+
+    test('throws when package.json version does not match expected tag', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: '1.2.4' }));
+
+      expect(() => verifyPackageJsonVersion('package.json', 'v1.2.3')).toThrow(
+        'Expected package.json version to be 1.2.3, but found 1.2.4'
+      );
+      expect(core.error).toHaveBeenCalledWith(
+        expect.stringContaining('Package.json version verification failed:')
+      );
     });
   });
 

--- a/action.yml
+++ b/action.yml
@@ -87,9 +87,12 @@ inputs:
   
   # Package.json handling
   update-package-json:
-    description: 'Whether to update package.json version'
+    description: 'Legacy package.json toggle. When package-json-mode is not set, true maps to update and false maps to ignore'
     required: false
     default: 'true'
+  package-json-mode:
+    description: 'How to handle package.json: update, verify, or ignore. Leave empty to fall back to update-package-json'
+    required: false
   package-json-path:
     description: 'Path to package.json file'
     required: false
@@ -104,10 +107,19 @@ inputs:
     description: 'Git user email for commits'
     required: false
     default: 'github-actions[bot]@users.noreply.github.com'
+
+  commit-changes:
+    description: 'Whether to commit and push branch changes before tagging'
+    required: false
+    default: 'true'
   
   # Trigger mode
   trigger-mode:
-    description: 'How the action was triggered (pr-merge, manual, workflow-call)'
+    description: 'How the action was triggered (pr-open, pr-merge, manual, workflow-call, push-main)'
+    required: false
+    default: 'auto-detect'
+  execution-mode:
+    description: 'Whether to validate a planned version or perform the final release (auto-detect, validate, release)'
     required: false
     default: 'auto-detect'
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29929,10 +29929,9 @@ const core = __nccwpck_require__(7484);
 const github = __nccwpck_require__(3228);
 const { execSync } = __nccwpck_require__(5317);
 const fs = __nccwpck_require__(9896);
-const path = __nccwpck_require__(6928);
 
-const { detectTriggerMode, parseLabels } = __nccwpck_require__(5804);
-const { calculateVersion, updatePackageJson } = __nccwpck_require__(321);
+const { detectTriggerMode, detectExecutionMode, parseLabels } = __nccwpck_require__(5804);
+const { calculateVersion, updatePackageJson, verifyPackageJsonVersion } = __nccwpck_require__(321);
 const { createRelease, createMajorRelease } = __nccwpck_require__(5712);
 
 async function run() {
@@ -29957,10 +29956,13 @@ async function run() {
       copyAssets: core.getBooleanInput('copy-assets'),
       autoGenerateNotes: core.getBooleanInput('auto-generate-notes'),
       updatePackageJson: core.getBooleanInput('update-package-json'),
+      packageJsonMode: core.getInput('package-json-mode'),
       packageJsonPath: core.getInput('package-json-path'),
       gitUserName: core.getInput('git-user-name'),
       gitUserEmail: core.getInput('git-user-email'),
-      triggerMode: core.getInput('trigger-mode')
+      triggerMode: core.getInput('trigger-mode'),
+      executionMode: core.getInput('execution-mode'),
+      commitChanges: core.getBooleanInput('commit-changes')
     };
 
     // Initialize GitHub client
@@ -29978,6 +29980,9 @@ async function run() {
     // Detect trigger mode
     const triggerMode = detectTriggerMode(inputs.triggerMode, context);
     core.info(`🔍 Detected trigger mode: ${triggerMode}`);
+
+    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode);
+    core.info(`🧭 Execution mode: ${executionMode}`);
 
     // Parse labels to determine release type
     const { releaseType, isPrerelease } = parseLabels(context, inputs, triggerMode);
@@ -29999,9 +30004,20 @@ async function run() {
     const newVersion = calculateVersion(latestVersion, releaseType, isPrerelease, inputs);
     core.info(`🆕 New version: ${newVersion}`);
 
-    // Update package.json if requested
-    if (inputs.updatePackageJson) {
-      updatePackageJson(inputs.packageJsonPath, newVersion);
+    handlePackageJson(inputs, newVersion);
+
+    setReleaseOutputs({
+      released: false,
+      version: newVersion,
+      previousVersion: latestVersion,
+      releaseType,
+      isPrerelease,
+      tagName: newVersion
+    });
+
+    if (executionMode === 'validate') {
+      core.info('🧪 Validation mode enabled. Skipping build, tag, and release creation.');
+      return;
     }
 
     // Setup Node.js and install dependencies
@@ -30017,10 +30033,15 @@ async function run() {
     configureGit(inputs);
 
     // Commit changes if any
-    await commitChanges(newVersion, inputs);
+    let shouldPushBranch = false;
+    if (inputs.commitChanges) {
+      shouldPushBranch = await commitChanges(newVersion, inputs);
+    } else {
+      core.info('📝 Skipping commit step because commit-changes is disabled');
+    }
 
     // Create and push tag
-    await createAndPushTag(newVersion);
+    await createAndPushTag(newVersion, { pushBranch: shouldPushBranch });
 
     // Generate release notes
     const releaseNotes = generateReleaseNotes(latestVersion, newVersion, inputs);
@@ -30036,14 +30057,16 @@ async function run() {
     core.info(`✅ Created release: ${release.html_url}`);
 
     // Set outputs
-    core.setOutput('released', 'true');
-    core.setOutput('version', newVersion);
-    core.setOutput('previous-version', latestVersion);
-    core.setOutput('release-type', releaseType);
-    core.setOutput('is-prerelease', isPrerelease.toString());
+    setReleaseOutputs({
+      released: true,
+      version: newVersion,
+      previousVersion: latestVersion,
+      releaseType,
+      isPrerelease,
+      tagName: newVersion
+    });
     core.setOutput('release-url', release.html_url);
     core.setOutput('release-id', release.id.toString());
-    core.setOutput('tag-name', newVersion);
 
     // Sync major version tag if requested and not a prerelease
     if (inputs.baseRelease && !isPrerelease) {
@@ -30067,6 +30090,37 @@ async function run() {
     core.error(`❌ Action failed: ${error.message}`);
     core.setFailed(error.message);
   }
+}
+
+function handlePackageJson(inputs, newVersion) {
+  const packageJsonMode = resolvePackageJsonMode(inputs);
+
+  switch (packageJsonMode) {
+    case 'update':
+      updatePackageJson(inputs.packageJsonPath, newVersion);
+      break;
+    case 'verify':
+      verifyPackageJsonVersion(inputs.packageJsonPath, newVersion);
+      break;
+    case 'ignore':
+      core.info('📦 Skipping package.json handling');
+      break;
+    default:
+      throw new Error(`Invalid package-json-mode: ${packageJsonMode}`);
+  }
+}
+
+function resolvePackageJsonMode(inputs) {
+  return inputs.packageJsonMode || (inputs.updatePackageJson ? 'update' : 'ignore');
+}
+
+function setReleaseOutputs({ released, version, previousVersion, releaseType, isPrerelease, tagName }) {
+  core.setOutput('released', released.toString());
+  core.setOutput('version', version);
+  core.setOutput('previous-version', previousVersion);
+  core.setOutput('release-type', releaseType);
+  core.setOutput('is-prerelease', isPrerelease.toString());
+  core.setOutput('tag-name', tagName);
 }
 
 function getLatestVersion() {
@@ -30181,30 +30235,62 @@ async function commitChanges(newVersion, inputs) {
       core.info('📝 Detected GitHub Action project - ensuring dist/ is committed...');
       
       // Add built files that are essential for GitHub Actions
-      execSync('git add dist/ || true', { stdio: 'inherit' });
-      execSync('git add coverage/ || true', { stdio: 'inherit' });
-      execSync('git add package.json || true', { stdio: 'inherit' });
+      tryGitAdd('dist/');
+      tryGitAdd('coverage/');
+
+      if (resolvePackageJsonMode(inputs) === 'update') {
+        tryGitAdd(inputs.packageJsonPath);
+      }
       
       // For GitHub Actions, always commit to ensure dist/ is included in releases
+      if (!hasStagedChanges()) {
+        core.info('No staged changes to commit');
+        return false;
+      }
+
       core.info('📝 Committing built files and version changes...');
-      execSync(`git commit -m "build: update dist and version for ${newVersion}" || true`);
+      execSync(`git commit -m "build: update dist and version for ${newVersion}"`, {
+        stdio: 'inherit'
+      });
+      return true;
     } else {
       // Non-GitHub Action project - use original logic
       const status = execSync('git status --porcelain', { encoding: 'utf8' });
       if (status.trim()) {
         core.info('📝 Committing version changes...');
         execSync('git add .');
-        execSync(`git commit -m "chore: bump version to ${newVersion}"`);
+        execSync(`git commit -m "chore: bump version to ${newVersion}"`, { stdio: 'inherit' });
+        return true;
       } else {
         core.info('No changes to commit');
+        return false;
       }
     }
   } catch (error) {
     core.info('No changes to commit or commit failed');
+    return false;
   }
 }
 
-async function createAndPushTag(newVersion) {
+function hasStagedChanges() {
+  try {
+    execSync('git diff --cached --quiet');
+    return false;
+  } catch (error) {
+    return true;
+  }
+}
+
+function tryGitAdd(pathspec) {
+  try {
+    execSync(`git add "${pathspec}"`, { stdio: 'inherit' });
+  } catch (error) {
+    core.info(`Skipping git add for ${pathspec}: ${error.message}`);
+  }
+}
+
+async function createAndPushTag(newVersion, options = {}) {
+  const { pushBranch = false } = options;
   core.info(`🏷️ Creating and pushing tag: ${newVersion}`);
   
   // Delete existing tag if it exists (locally and remote)
@@ -30224,7 +30310,13 @@ async function createAndPushTag(newVersion) {
   
   // Create new tag
   execSync(`git tag -a "${newVersion}" -m "Release ${newVersion}"`);
-  execSync(`git push origin HEAD`);
+
+  if (pushBranch) {
+    execSync('git push origin HEAD');
+  } else {
+    core.info('Skipping branch push; only pushing the release tag');
+  }
+
   execSync(`git push origin "${newVersion}"`);
 }
 
@@ -30496,8 +30588,11 @@ function detectTriggerMode(inputMode, context) {
 
   const eventName = context.eventName;
   
-  if (eventName === 'pull_request' && context.payload.pull_request?.merged) {
-    return 'pr-merge';
+  if (eventName === 'pull_request') {
+    if (context.payload.pull_request?.merged) {
+      return 'pr-merge';
+    }
+    return 'pr-open';
   } else if (eventName === 'workflow_dispatch') {
     return 'manual';
   } else if (eventName === 'workflow_call') {
@@ -30509,11 +30604,23 @@ function detectTriggerMode(inputMode, context) {
   return 'unknown';
 }
 
+function detectExecutionMode(inputMode, triggerMode) {
+  if (inputMode !== 'auto-detect') {
+    return inputMode;
+  }
+
+  if (triggerMode === 'pr-open') {
+    return 'validate';
+  }
+
+  return 'release';
+}
+
 function parseLabels(context, inputs, triggerMode) {
   let releaseType = 'none';
   let isPrerelease = false;
   
-  if (triggerMode === 'pr-merge') {
+  if (triggerMode === 'pr-open' || triggerMode === 'pr-merge') {
     // Parse PR labels
     const labels = context.payload.pull_request?.labels?.map(label => label.name) || [];
     core.info(`PR labels: ${labels.join(', ')}`);
@@ -30589,6 +30696,14 @@ function validateInputs(inputs) {
   if (!['npm', 'yarn', 'pnpm'].includes(inputs.packageManager)) {
     errors.push('package-manager must be one of: npm, yarn, pnpm');
   }
+
+  if (!['auto-detect', 'validate', 'release'].includes(inputs.executionMode)) {
+    errors.push('execution-mode must be one of: auto-detect, validate, release');
+  }
+
+  if (inputs.packageJsonMode && !['update', 'verify', 'ignore'].includes(inputs.packageJsonMode)) {
+    errors.push('package-json-mode must be one of: update, verify, ignore');
+  }
   
   if (errors.length > 0) {
     throw new Error(`Invalid inputs: ${errors.join(', ')}`);
@@ -30601,6 +30716,7 @@ function sleep(ms) {
 
 module.exports = {
   detectTriggerMode,
+  detectExecutionMode,
   parseLabels,
   parseVersion,
   formatVersion,
@@ -30652,7 +30768,7 @@ function calculateVersion(latestVersion, releaseType, isPrerelease, inputs) {
 function updatePackageJson(packageJsonPath, newVersion) {
   if (!fs.existsSync(packageJsonPath)) {
     core.warning(`Package.json not found at ${packageJsonPath}, skipping version update`);
-    return;
+    return false;
   }
   
   try {
@@ -30664,8 +30780,39 @@ function updatePackageJson(packageJsonPath, newVersion) {
     
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
     core.info(`✅ Updated ${packageJsonPath} version to ${versionWithoutV}`);
+    return true;
   } catch (error) {
     core.warning(`Failed to update package.json: ${error.message}`);
+    return false;
+  }
+}
+
+function normalizePackageJsonVersion(version) {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+function verifyPackageJsonVersion(packageJsonPath, expectedVersion) {
+  if (!fs.existsSync(packageJsonPath)) {
+    core.warning(`Package.json not found at ${packageJsonPath}, skipping version verification`);
+    return false;
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const actualVersion = normalizePackageJsonVersion(packageJson.version || '');
+    const expectedVersionWithoutV = normalizePackageJsonVersion(expectedVersion);
+
+    if (actualVersion !== expectedVersionWithoutV) {
+      throw new Error(
+        `Expected ${packageJsonPath} version to be ${expectedVersionWithoutV}, but found ${actualVersion || '(empty)'}`
+      );
+    }
+
+    core.info(`✅ Verified ${packageJsonPath} version matches ${expectedVersionWithoutV}`);
+    return true;
+  } catch (error) {
+    core.error(`Package.json version verification failed: ${error.message}`);
+    throw error;
   }
 }
 
@@ -30739,6 +30886,7 @@ function compareVersions(version1, version2) {
 module.exports = {
   calculateVersion,
   updatePackageJson,
+  verifyPackageJsonVersion,
   parseExistingPrerelease,
   incrementPrerelease,
   validateVersion,

--- a/examples/protected-branch-release.yml
+++ b/examples/protected-branch-release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dnogu/semantic-release-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          execution-mode: release
+          package-json-mode: verify
+          commit-changes: false
+          base_release: true

--- a/examples/protected-branch-validation.yml
+++ b/examples/protected-branch-validation.yml
@@ -1,0 +1,21 @@
+name: Version Check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dnogu/semantic-release-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          execution-mode: validate
+          package-json-mode: verify

--- a/src/main.js
+++ b/src/main.js
@@ -2,10 +2,9 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const { execSync } = require('child_process');
 const fs = require('fs');
-const path = require('path');
 
-const { detectTriggerMode, parseLabels } = require('./utils');
-const { calculateVersion, updatePackageJson } = require('./version');
+const { detectTriggerMode, detectExecutionMode, parseLabels } = require('./utils');
+const { calculateVersion, updatePackageJson, verifyPackageJsonVersion } = require('./version');
 const { createRelease, createMajorRelease } = require('./release');
 
 async function run() {
@@ -30,10 +29,13 @@ async function run() {
       copyAssets: core.getBooleanInput('copy-assets'),
       autoGenerateNotes: core.getBooleanInput('auto-generate-notes'),
       updatePackageJson: core.getBooleanInput('update-package-json'),
+      packageJsonMode: core.getInput('package-json-mode'),
       packageJsonPath: core.getInput('package-json-path'),
       gitUserName: core.getInput('git-user-name'),
       gitUserEmail: core.getInput('git-user-email'),
-      triggerMode: core.getInput('trigger-mode')
+      triggerMode: core.getInput('trigger-mode'),
+      executionMode: core.getInput('execution-mode'),
+      commitChanges: core.getBooleanInput('commit-changes')
     };
 
     // Initialize GitHub client
@@ -51,6 +53,9 @@ async function run() {
     // Detect trigger mode
     const triggerMode = detectTriggerMode(inputs.triggerMode, context);
     core.info(`🔍 Detected trigger mode: ${triggerMode}`);
+
+    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode);
+    core.info(`🧭 Execution mode: ${executionMode}`);
 
     // Parse labels to determine release type
     const { releaseType, isPrerelease } = parseLabels(context, inputs, triggerMode);
@@ -72,9 +77,20 @@ async function run() {
     const newVersion = calculateVersion(latestVersion, releaseType, isPrerelease, inputs);
     core.info(`🆕 New version: ${newVersion}`);
 
-    // Update package.json if requested
-    if (inputs.updatePackageJson) {
-      updatePackageJson(inputs.packageJsonPath, newVersion);
+    handlePackageJson(inputs, newVersion);
+
+    setReleaseOutputs({
+      released: false,
+      version: newVersion,
+      previousVersion: latestVersion,
+      releaseType,
+      isPrerelease,
+      tagName: newVersion
+    });
+
+    if (executionMode === 'validate') {
+      core.info('🧪 Validation mode enabled. Skipping build, tag, and release creation.');
+      return;
     }
 
     // Setup Node.js and install dependencies
@@ -90,10 +106,15 @@ async function run() {
     configureGit(inputs);
 
     // Commit changes if any
-    await commitChanges(newVersion, inputs);
+    let shouldPushBranch = false;
+    if (inputs.commitChanges) {
+      shouldPushBranch = await commitChanges(newVersion, inputs);
+    } else {
+      core.info('📝 Skipping commit step because commit-changes is disabled');
+    }
 
     // Create and push tag
-    await createAndPushTag(newVersion);
+    await createAndPushTag(newVersion, { pushBranch: shouldPushBranch });
 
     // Generate release notes
     const releaseNotes = generateReleaseNotes(latestVersion, newVersion, inputs);
@@ -109,14 +130,16 @@ async function run() {
     core.info(`✅ Created release: ${release.html_url}`);
 
     // Set outputs
-    core.setOutput('released', 'true');
-    core.setOutput('version', newVersion);
-    core.setOutput('previous-version', latestVersion);
-    core.setOutput('release-type', releaseType);
-    core.setOutput('is-prerelease', isPrerelease.toString());
+    setReleaseOutputs({
+      released: true,
+      version: newVersion,
+      previousVersion: latestVersion,
+      releaseType,
+      isPrerelease,
+      tagName: newVersion
+    });
     core.setOutput('release-url', release.html_url);
     core.setOutput('release-id', release.id.toString());
-    core.setOutput('tag-name', newVersion);
 
     // Sync major version tag if requested and not a prerelease
     if (inputs.baseRelease && !isPrerelease) {
@@ -140,6 +163,37 @@ async function run() {
     core.error(`❌ Action failed: ${error.message}`);
     core.setFailed(error.message);
   }
+}
+
+function handlePackageJson(inputs, newVersion) {
+  const packageJsonMode = resolvePackageJsonMode(inputs);
+
+  switch (packageJsonMode) {
+    case 'update':
+      updatePackageJson(inputs.packageJsonPath, newVersion);
+      break;
+    case 'verify':
+      verifyPackageJsonVersion(inputs.packageJsonPath, newVersion);
+      break;
+    case 'ignore':
+      core.info('📦 Skipping package.json handling');
+      break;
+    default:
+      throw new Error(`Invalid package-json-mode: ${packageJsonMode}`);
+  }
+}
+
+function resolvePackageJsonMode(inputs) {
+  return inputs.packageJsonMode || (inputs.updatePackageJson ? 'update' : 'ignore');
+}
+
+function setReleaseOutputs({ released, version, previousVersion, releaseType, isPrerelease, tagName }) {
+  core.setOutput('released', released.toString());
+  core.setOutput('version', version);
+  core.setOutput('previous-version', previousVersion);
+  core.setOutput('release-type', releaseType);
+  core.setOutput('is-prerelease', isPrerelease.toString());
+  core.setOutput('tag-name', tagName);
 }
 
 function getLatestVersion() {
@@ -254,30 +308,62 @@ async function commitChanges(newVersion, inputs) {
       core.info('📝 Detected GitHub Action project - ensuring dist/ is committed...');
       
       // Add built files that are essential for GitHub Actions
-      execSync('git add dist/ || true', { stdio: 'inherit' });
-      execSync('git add coverage/ || true', { stdio: 'inherit' });
-      execSync('git add package.json || true', { stdio: 'inherit' });
+      tryGitAdd('dist/');
+      tryGitAdd('coverage/');
+
+      if (resolvePackageJsonMode(inputs) === 'update') {
+        tryGitAdd(inputs.packageJsonPath);
+      }
       
       // For GitHub Actions, always commit to ensure dist/ is included in releases
+      if (!hasStagedChanges()) {
+        core.info('No staged changes to commit');
+        return false;
+      }
+
       core.info('📝 Committing built files and version changes...');
-      execSync(`git commit -m "build: update dist and version for ${newVersion}" || true`);
+      execSync(`git commit -m "build: update dist and version for ${newVersion}"`, {
+        stdio: 'inherit'
+      });
+      return true;
     } else {
       // Non-GitHub Action project - use original logic
       const status = execSync('git status --porcelain', { encoding: 'utf8' });
       if (status.trim()) {
         core.info('📝 Committing version changes...');
         execSync('git add .');
-        execSync(`git commit -m "chore: bump version to ${newVersion}"`);
+        execSync(`git commit -m "chore: bump version to ${newVersion}"`, { stdio: 'inherit' });
+        return true;
       } else {
         core.info('No changes to commit');
+        return false;
       }
     }
   } catch (error) {
     core.info('No changes to commit or commit failed');
+    return false;
   }
 }
 
-async function createAndPushTag(newVersion) {
+function hasStagedChanges() {
+  try {
+    execSync('git diff --cached --quiet');
+    return false;
+  } catch (error) {
+    return true;
+  }
+}
+
+function tryGitAdd(pathspec) {
+  try {
+    execSync(`git add "${pathspec}"`, { stdio: 'inherit' });
+  } catch (error) {
+    core.info(`Skipping git add for ${pathspec}: ${error.message}`);
+  }
+}
+
+async function createAndPushTag(newVersion, options = {}) {
+  const { pushBranch = false } = options;
   core.info(`🏷️ Creating and pushing tag: ${newVersion}`);
   
   // Delete existing tag if it exists (locally and remote)
@@ -297,7 +383,13 @@ async function createAndPushTag(newVersion) {
   
   // Create new tag
   execSync(`git tag -a "${newVersion}" -m "Release ${newVersion}"`);
-  execSync(`git push origin HEAD`);
+
+  if (pushBranch) {
+    execSync('git push origin HEAD');
+  } else {
+    core.info('Skipping branch push; only pushing the release tag');
+  }
+
   execSync(`git push origin "${newVersion}"`);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,11 @@ function detectTriggerMode(inputMode, context) {
 
   const eventName = context.eventName;
   
-  if (eventName === 'pull_request' && context.payload.pull_request?.merged) {
-    return 'pr-merge';
+  if (eventName === 'pull_request') {
+    if (context.payload.pull_request?.merged) {
+      return 'pr-merge';
+    }
+    return 'pr-open';
   } else if (eventName === 'workflow_dispatch') {
     return 'manual';
   } else if (eventName === 'workflow_call') {
@@ -21,11 +24,23 @@ function detectTriggerMode(inputMode, context) {
   return 'unknown';
 }
 
+function detectExecutionMode(inputMode, triggerMode) {
+  if (inputMode !== 'auto-detect') {
+    return inputMode;
+  }
+
+  if (triggerMode === 'pr-open') {
+    return 'validate';
+  }
+
+  return 'release';
+}
+
 function parseLabels(context, inputs, triggerMode) {
   let releaseType = 'none';
   let isPrerelease = false;
   
-  if (triggerMode === 'pr-merge') {
+  if (triggerMode === 'pr-open' || triggerMode === 'pr-merge') {
     // Parse PR labels
     const labels = context.payload.pull_request?.labels?.map(label => label.name) || [];
     core.info(`PR labels: ${labels.join(', ')}`);
@@ -101,6 +116,14 @@ function validateInputs(inputs) {
   if (!['npm', 'yarn', 'pnpm'].includes(inputs.packageManager)) {
     errors.push('package-manager must be one of: npm, yarn, pnpm');
   }
+
+  if (!['auto-detect', 'validate', 'release'].includes(inputs.executionMode)) {
+    errors.push('execution-mode must be one of: auto-detect, validate, release');
+  }
+
+  if (inputs.packageJsonMode && !['update', 'verify', 'ignore'].includes(inputs.packageJsonMode)) {
+    errors.push('package-json-mode must be one of: update, verify, ignore');
+  }
   
   if (errors.length > 0) {
     throw new Error(`Invalid inputs: ${errors.join(', ')}`);
@@ -113,6 +136,7 @@ function sleep(ms) {
 
 module.exports = {
   detectTriggerMode,
+  detectExecutionMode,
   parseLabels,
   parseVersion,
   formatVersion,

--- a/src/version.js
+++ b/src/version.js
@@ -36,7 +36,7 @@ function calculateVersion(latestVersion, releaseType, isPrerelease, inputs) {
 function updatePackageJson(packageJsonPath, newVersion) {
   if (!fs.existsSync(packageJsonPath)) {
     core.warning(`Package.json not found at ${packageJsonPath}, skipping version update`);
-    return;
+    return false;
   }
   
   try {
@@ -48,8 +48,39 @@ function updatePackageJson(packageJsonPath, newVersion) {
     
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
     core.info(`✅ Updated ${packageJsonPath} version to ${versionWithoutV}`);
+    return true;
   } catch (error) {
     core.warning(`Failed to update package.json: ${error.message}`);
+    return false;
+  }
+}
+
+function normalizePackageJsonVersion(version) {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+function verifyPackageJsonVersion(packageJsonPath, expectedVersion) {
+  if (!fs.existsSync(packageJsonPath)) {
+    core.warning(`Package.json not found at ${packageJsonPath}, skipping version verification`);
+    return false;
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const actualVersion = normalizePackageJsonVersion(packageJson.version || '');
+    const expectedVersionWithoutV = normalizePackageJsonVersion(expectedVersion);
+
+    if (actualVersion !== expectedVersionWithoutV) {
+      throw new Error(
+        `Expected ${packageJsonPath} version to be ${expectedVersionWithoutV}, but found ${actualVersion || '(empty)'}`
+      );
+    }
+
+    core.info(`✅ Verified ${packageJsonPath} version matches ${expectedVersionWithoutV}`);
+    return true;
+  } catch (error) {
+    core.error(`Package.json version verification failed: ${error.message}`);
+    throw error;
   }
 }
 
@@ -123,6 +154,7 @@ function compareVersions(version1, version2) {
 module.exports = {
   calculateVersion,
   updatePackageJson,
+  verifyPackageJsonVersion,
   parseExistingPrerelease,
   incrementPrerelease,
   validateVersion,


### PR DESCRIPTION
## Summary
This PR adds a protected-branch-safe release flow for repos that cannot push version bump commits back to `main`.

## What Changed
- added `execution-mode` so the action can run in PR validation mode or final release mode
- added `package-json-mode` to update, verify, or ignore `package.json`
- added `commit-changes` so merge-time releases can create tags without pushing branch commits
- verified the merged `package.json` version can be required to match the tag being created
- updated tests, docs, examples, and the committed `dist/index.js` bundle

## Why
The old flow always edited `package.json`, committed it, and pushed `HEAD` during the release job. That breaks down on protected branches and makes PR-based version verification harder to enforce.

## Impact
- Node projects can validate the planned release version in PRs and release safely on merge
- non-Node repos still compute semantic versions from tags and labels as before, and can ignore `package.json`
- label changes on a PR do not compound multiple increments because the version is always recalculated from the latest real tag

## Validation
- patched source, tests, docs, examples, and `dist/index.js`
- could not run `npm test` or `npm run build` in this environment because `node` and `npm` are not installed here
