### PR TITLE
fix: run CI for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What changed
This removes the draft-only job guard from the repository CI workflow so pull requests always run the existing install, test, and build steps.

## Why
The PR workflow already defined `npm ci`, unit tests, and the action bundle build, but the entire job was skipped whenever the pull request was still marked as draft. That made draft PRs look like they were not running CI at all.

## Impact
Pull requests targeting `main` now execute the CI workflow on `opened`, `synchronize`, `reopened`, and `ready_for_review` events regardless of draft status.

## Validation
I verified the workflow YAML parses cleanly after the change. Local `npm` checks could not be run in this environment because `node`/`npm` are not installed here.