### PR TITLE
feat: default open PRs to prepare mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This avoids branch-protection conflicts and prevents accidental double bumps. Th
 
 ### PR Validation Workflow
 
+If you want a read-only PR check that calculates the planned version without changing the branch, use explicit `validate` mode.
+
 ```yaml
 name: Version Check
 on:
@@ -155,9 +157,9 @@ jobs:
 
 With this setup, the merged `package.json` version must already match the tag that gets created by the release job.
 
-### Optional PR Preparation Workflow
+### PR Preparation Workflow
 
-If you want the branch to be updated during the PR itself, you can opt into `prepare` mode. This mode updates files, runs install/test/build, commits the results, and pushes them back to the PR branch without creating a tag or release.
+For same-repository pull requests, `execution-mode: auto-detect` now defaults to `prepare`. This mode updates files, runs install/test/build, commits the results, and pushes them back to the PR branch without creating a tag or release. Fork PRs automatically fall back to `validate` because the action cannot push back to fork branches.
 
 ```yaml
 name: Prepare Release PR
@@ -232,7 +234,7 @@ This workflow is intended for same-repository PR branches. Fork PRs cannot be pu
 
     # Release execution
     commit-changes: true           # also controls branch commits in prepare mode
-    execution-mode: 'auto-detect'  # auto-detect, validate, prepare, release
+    execution-mode: 'auto-detect'  # prepare for same-repo PRs, validate for fork PRs, release after merge
 ```
 
 ## 📤 Outputs

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -70,8 +70,34 @@ describe('utils', () => {
       expect(detectExecutionMode('prepare', 'pr-open')).toBe('prepare');
     });
 
-    test('uses validate mode for open PRs', () => {
-      expect(detectExecutionMode('auto-detect', 'pr-open')).toBe('validate');
+    test('uses prepare mode for same-repository open PRs', () => {
+      const context = {
+        payload: {
+          pull_request: {
+            head: {
+              repo: { full_name: 'octocat/demo-repo' }
+            }
+          }
+        },
+        repo: { owner: 'octocat', repo: 'demo-repo' }
+      };
+
+      expect(detectExecutionMode('auto-detect', 'pr-open', context)).toBe('prepare');
+    });
+
+    test('uses validate mode for fork pull requests', () => {
+      const context = {
+        payload: {
+          pull_request: {
+            head: {
+              repo: { full_name: 'someone-else/demo-repo' }
+            }
+          }
+        },
+        repo: { owner: 'octocat', repo: 'demo-repo' }
+      };
+
+      expect(detectExecutionMode('auto-detect', 'pr-open', context)).toBe('validate');
     });
 
     test('uses release mode for merged PRs and other triggers', () => {

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ inputs:
     required: false
     default: 'auto-detect'
   execution-mode:
-    description: 'Whether to validate a planned version, prepare a PR branch, or perform the final release (auto-detect, validate, prepare, release)'
+    description: 'Whether to validate a planned version, prepare a PR branch, or perform the final release (auto-detect defaults to prepare for same-repo PRs, validate for fork PRs, and release after merge)'
     required: false
     default: 'auto-detect'
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29977,7 +29977,7 @@ async function run() {
     const triggerMode = detectTriggerMode(inputs.triggerMode, context);
     core.info(`🔍 Detected trigger mode: ${triggerMode}`);
 
-    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode);
+    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode, context);
     core.info(`🧭 Execution mode: ${executionMode}`);
 
     const { releaseType, isPrerelease } = parseLabels(context, inputs, triggerMode);
@@ -30608,13 +30608,22 @@ function detectTriggerMode(inputMode, context) {
   return 'unknown';
 }
 
-function detectExecutionMode(inputMode, triggerMode) {
+function detectExecutionMode(inputMode, triggerMode, context = github.context) {
   if (inputMode !== 'auto-detect') {
     return inputMode;
   }
 
   if (triggerMode === 'pr-open') {
-    return 'validate';
+    const headRepo = context.payload?.pull_request?.head?.repo?.full_name;
+    const baseRepo = context.repo?.owner && context.repo?.repo
+      ? `${context.repo.owner}/${context.repo.repo}`
+      : null;
+
+    if (headRepo && baseRepo && headRepo !== baseRepo) {
+      return 'validate';
+    }
+
+    return 'prepare';
   }
 
   return 'release';

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ async function run() {
     const triggerMode = detectTriggerMode(inputs.triggerMode, context);
     core.info(`🔍 Detected trigger mode: ${triggerMode}`);
 
-    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode);
+    const executionMode = detectExecutionMode(inputs.executionMode, triggerMode, context);
     core.info(`🧭 Execution mode: ${executionMode}`);
 
     const { releaseType, isPrerelease } = parseLabels(context, inputs, triggerMode);

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,13 +24,22 @@ function detectTriggerMode(inputMode, context) {
   return 'unknown';
 }
 
-function detectExecutionMode(inputMode, triggerMode) {
+function detectExecutionMode(inputMode, triggerMode, context = github.context) {
   if (inputMode !== 'auto-detect') {
     return inputMode;
   }
 
   if (triggerMode === 'pr-open') {
-    return 'validate';
+    const headRepo = context.payload?.pull_request?.head?.repo?.full_name;
+    const baseRepo = context.repo?.owner && context.repo?.repo
+      ? `${context.repo.owner}/${context.repo.repo}`
+      : null;
+
+    if (headRepo && baseRepo && headRepo !== baseRepo) {
+      return 'validate';
+    }
+
+    return 'prepare';
   }
 
   return 'release';


### PR DESCRIPTION
## What changed
This updates `auto-detect` so open same-repository pull requests default to `prepare` instead of `validate`.

## Why
The expected default for open PRs is to prepare the branch by updating files and running the install/test/build flow. Fork PRs still fall back to `validate` because the action cannot safely push preparation commits back to fork branches.

## Impact
Same-repo PRs now auto-detect to `prepare`.
Fork PRs continue to use `validate`.
Merged PRs continue to use `release`.

## Validation
Updated the mode-selection logic, tests, docs, and the committed `dist/index.js` runtime bundle.
I could not run local Node/Jest/build checks in this environment because `node` and `npm` are not installed here.