### PR TITLE
fix: sync prepare pushes with remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ With this setup, the merged `package.json` version must already match the tag th
 
 ### PR Preparation Workflow
 
-For same-repository pull requests, `execution-mode: auto-detect` now defaults to `prepare`. This mode updates files, runs install/test/build, commits the results, and pushes them back to the PR branch without creating a tag or release. Fork PRs automatically fall back to `validate` because the action cannot push back to fork branches.
+For same-repository pull requests, `execution-mode: auto-detect` now defaults to `prepare`. This mode updates files, runs install/test/build, commits the results, and pushes them back to the PR branch without creating a tag or release. Before pushing, the action fetches and rebases onto the latest PR branch tip so it is less likely to fail when another update lands mid-run. Fork PRs automatically fall back to `validate` because the action cannot push back to fork branches.
 
 ```yaml
 name: Prepare Release PR

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -263,10 +263,63 @@ describe('main.run', () => {
       'git commit -m "build: update dist and version for v1.3.0"',
       { stdio: 'inherit' }
     );
+    expect(execSync).toHaveBeenCalledWith('git fetch origin "feature/release-prep"');
+    expect(execSync).toHaveBeenCalledWith('git rebase "origin/feature/release-prep"');
     expect(execSync).toHaveBeenCalledWith('git push origin HEAD:feature/release-prep');
     expect(release.createRelease).not.toHaveBeenCalled();
     expect(core.setOutput).toHaveBeenCalledWith('released', 'false');
     expect(core.setOutput).toHaveBeenCalledWith('version', 'v1.3.0');
+  });
+
+  test('retries prepare push once when the PR branch moves during the run', async () => {
+    setupCoreInputs({
+      'package-json-mode': 'update',
+      'execution-mode': 'prepare'
+    });
+    setupFs({ packageJson: true, actionYml: true });
+    setupExecSync({ stagedChanges: true });
+
+    github.context.payload.pull_request = {
+      merged: false,
+      labels: [{ name: 'minor' }],
+      head: {
+        ref: 'feature/release-prep',
+        repo: { full_name: 'octocat/demo-repo' }
+      }
+    };
+
+    utils.detectTriggerMode.mockReturnValue('pr-open');
+    utils.detectExecutionMode.mockReturnValue('prepare');
+    utils.parseLabels.mockReturnValue({ releaseType: 'minor', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.3.0');
+
+    const baseExecSync = execSync.getMockImplementation();
+    let pushAttempts = 0;
+    execSync.mockImplementation(command => {
+      if (command === 'git push origin HEAD:feature/release-prep') {
+        pushAttempts += 1;
+        if (pushAttempts === 1) {
+          throw new Error('Updates were rejected because a pushed branch tip is behind its remote counterpart');
+        }
+      }
+
+      return baseExecSync(command);
+    });
+
+    await run();
+
+    expect(core.warning).toHaveBeenCalledWith(
+      'Remote PR branch moved while prepare mode was running. Retrying push for feature/release-prep.'
+    );
+    expect(
+      execSync.mock.calls.filter(([command]) => command === 'git fetch origin "feature/release-prep"')
+    ).toHaveLength(2);
+    expect(
+      execSync.mock.calls.filter(([command]) => command === 'git rebase "origin/feature/release-prep"')
+    ).toHaveLength(2);
+    expect(
+      execSync.mock.calls.filter(([command]) => command === 'git push origin HEAD:feature/release-prep')
+    ).toHaveLength(2);
   });
 
   test('can verify package.json and create a tag without pushing the branch', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30298,8 +30298,27 @@ async function pushBranchChanges(context) {
     throw new Error('Cannot push preparation changes to a pull request from a fork');
   }
 
-  core.info(`⬆️ Pushing preparation changes back to PR branch: ${headRef}`);
-  execSync(`git push origin HEAD:${headRef}`);
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      core.info(`🔄 Syncing preparation commit with latest PR branch state: ${headRef}`);
+      execSync(`git fetch origin "${headRef}"`);
+      execSync(`git rebase "origin/${headRef}"`);
+
+      core.info(`⬆️ Pushing preparation changes back to PR branch: ${headRef}`);
+      execSync(`git push origin HEAD:${headRef}`);
+      return;
+    } catch (error) {
+      const message = error.message || '';
+      const shouldRetry = /behind its remote counterpart|non-fast-forward|fetch first|failed to push/i.test(message);
+
+      if (attempt < 2 && shouldRetry) {
+        core.warning(`Remote PR branch moved while prepare mode was running. Retrying push for ${headRef}.`);
+        continue;
+      }
+
+      throw error;
+    }
+  }
 }
 
 async function createAndPushTag(newVersion, options = {}) {

--- a/src/main.js
+++ b/src/main.js
@@ -371,8 +371,27 @@ async function pushBranchChanges(context) {
     throw new Error('Cannot push preparation changes to a pull request from a fork');
   }
 
-  core.info(`⬆️ Pushing preparation changes back to PR branch: ${headRef}`);
-  execSync(`git push origin HEAD:${headRef}`);
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      core.info(`🔄 Syncing preparation commit with latest PR branch state: ${headRef}`);
+      execSync(`git fetch origin "${headRef}"`);
+      execSync(`git rebase "origin/${headRef}"`);
+
+      core.info(`⬆️ Pushing preparation changes back to PR branch: ${headRef}`);
+      execSync(`git push origin HEAD:${headRef}`);
+      return;
+    } catch (error) {
+      const message = error.message || '';
+      const shouldRetry = /behind its remote counterpart|non-fast-forward|fetch first|failed to push/i.test(message);
+
+      if (attempt < 2 && shouldRetry) {
+        core.warning(`Remote PR branch moved while prepare mode was running. Retrying push for ${headRef}.`);
+        continue;
+      }
+
+      throw error;
+    }
+  }
 }
 
 async function createAndPushTag(newVersion, options = {}) {


### PR DESCRIPTION
## What changed
This updates prepare mode to sync with the latest PR branch tip before pushing generated preparation commits back to the branch.

## Why
Prepare mode could fail with a non-fast-forward error when the PR branch moved while the workflow was running. That caused `git push origin HEAD:<branch>` to be rejected even though the generated changes were valid.

## Impact
Prepare mode now fetches and rebases onto the latest remote PR branch before pushing, and retries once if the branch moves during the run.

## Validation
Added regression coverage for the prepare push flow and the non-fast-forward retry case.
I could not run local Node/Jest/build checks in this environment because `node` and `npm` are not installed here.