### PR TITLE
feat: add release-only execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,35 @@ jobs:
 
 With this setup, the merged `package.json` version must already match the tag that gets created by the release job.
 
+### Release-Only Workflow
+
+If you want the merged PR flow to create only the semantic version tag, the GitHub release, and the synced major version tag when `base_release: true`, use `release-only`. This mode skips `package.json` handling, install, test, build, and branch commit/push steps.
+
+```yaml
+name: Release
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dnogu/semantic-release-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          execution-mode: release-only
+          base_release: true
+```
+
 ### PR Preparation Workflow
 
 For same-repository pull requests, `execution-mode: auto-detect` now defaults to `prepare`. This mode updates files, runs install/test/build, commits the results, and pushes them back to the PR branch without creating a tag or release. Before pushing, the action fetches and rebases onto the latest PR branch tip so it is less likely to fail when another update lands mid-run. Fork PRs automatically fall back to `validate` because the action cannot push back to fork branches.
@@ -234,7 +263,7 @@ This workflow is intended for same-repository PR branches. Fork PRs cannot be pu
 
     # Release execution
     commit-changes: true           # also controls branch commits in prepare mode
-    execution-mode: 'auto-detect'  # prepare for same-repo PRs, validate for fork PRs, release after merge
+    execution-mode: 'auto-detect'  # prepare for same-repo PRs, validate for fork PRs, release after merge; or set release-only explicitly
 ```
 
 ## 📤 Outputs
@@ -339,7 +368,17 @@ jobs:
     commit-changes: false
 ```
 
-### Scenario 6: PR Preparation
+### Scenario 6: Release-Only Merge Flow
+
+```yaml
+- uses: dnogu/semantic-release-action@v1
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    execution-mode: release-only
+    base_release: true
+```
+
+### Scenario 7: PR Preparation
 
 ```yaml
 - uses: dnogu/semantic-release-action@v1

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -347,6 +347,61 @@ describe('main.run', () => {
     expect(execSync).toHaveBeenCalledWith('git push origin "v1.2.4"');
   });
 
+  test('release-only creates the tag and GitHub release without package.json handling or local checks', async () => {
+    setupCoreInputs(
+      {
+        'package-json-mode': 'verify',
+        'execution-mode': 'release-only'
+      },
+      { 'commit-changes': true }
+    );
+    setupFs({ packageJson: true, actionYml: true });
+
+    utils.detectTriggerMode.mockReturnValue('pr-merge');
+    utils.detectExecutionMode.mockReturnValue('release-only');
+    utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: false });
+    version.calculateVersion.mockReturnValue('v1.2.4');
+    release.createRelease.mockResolvedValue({
+      id: 103,
+      html_url: 'https://example.com/releases/v1.2.4'
+    });
+    release.createMajorRelease.mockResolvedValue({ tag: 'v1', version: 'v1.2.4' });
+
+    await run();
+
+    expect(version.verifyPackageJsonVersion).not.toHaveBeenCalled();
+    expect(version.updatePackageJson).not.toHaveBeenCalled();
+    expect(execSync).not.toHaveBeenCalledWith('npm ci', { stdio: 'inherit' });
+    expect(execSync).not.toHaveBeenCalledWith('npm test', { stdio: 'inherit' });
+    expect(execSync).not.toHaveBeenCalledWith('npm run build', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith(
+      'git config --local user.email "github-actions[bot]@users.noreply.github.com"'
+    );
+    expect(execSync).toHaveBeenCalledWith(
+      'git config --local user.name "github-actions[bot]"'
+    );
+    expect(execSync).toHaveBeenCalledWith('git push origin "v1.2.4"');
+    expect(execSync.mock.calls.filter(([command]) => command.startsWith('git commit '))).toHaveLength(0);
+    expect(execSync.mock.calls.filter(([command]) => command === 'git push origin HEAD')).toHaveLength(0);
+    expect(release.createRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        tagName: 'v1.2.4',
+        prerelease: false
+      })
+    );
+    expect(release.createMajorRelease).toHaveBeenCalledWith(
+      { rest: {} },
+      github.context,
+      expect.objectContaining({
+        majorVersion: 'v1',
+        fullVersion: 'v1.2.4'
+      })
+    );
+    expect(core.setOutput).toHaveBeenCalledWith('released', 'true');
+  });
+
   test('does not create major release for prereleases', async () => {
     utils.detectTriggerMode.mockReturnValue('pr-merge');
     utils.parseLabels.mockReturnValue({ releaseType: 'patch', isPrerelease: true });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -67,6 +67,7 @@ describe('utils', () => {
   describe('detectExecutionMode', () => {
     test('returns explicit mode when auto-detect is not used', () => {
       expect(detectExecutionMode('release', 'pr-open')).toBe('release');
+      expect(detectExecutionMode('release-only', 'pr-merge')).toBe('release-only');
       expect(detectExecutionMode('prepare', 'pr-open')).toBe('prepare');
     });
 
@@ -257,7 +258,7 @@ describe('utils', () => {
         validateInputs({
           githubToken: 'token',
           packageManager: 'npm',
-          executionMode: 'prepare',
+          executionMode: 'release-only',
           packageJsonMode: 'update'
         })
       ).not.toThrow();
@@ -298,7 +299,7 @@ describe('utils', () => {
           packageJsonMode: 'update'
         })
       ).toThrow(
-        'Invalid inputs: execution-mode must be one of: auto-detect, validate, prepare, release'
+        'Invalid inputs: execution-mode must be one of: auto-detect, validate, prepare, release, release-only'
       );
     });
 
@@ -324,7 +325,7 @@ describe('utils', () => {
           packageJsonMode: 'sync'
         })
       ).toThrow(
-        'Invalid inputs: github-token is required, package-manager must be one of: npm, yarn, pnpm, execution-mode must be one of: auto-detect, validate, prepare, release, package-json-mode must be one of: update, verify, ignore'
+        'Invalid inputs: github-token is required, package-manager must be one of: npm, yarn, pnpm, execution-mode must be one of: auto-detect, validate, prepare, release, release-only, package-json-mode must be one of: update, verify, ignore'
       );
     });
   });

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ inputs:
     required: false
     default: 'auto-detect'
   execution-mode:
-    description: 'Whether to validate a planned version, prepare a PR branch, or perform the final release (auto-detect defaults to prepare for same-repo PRs, validate for fork PRs, and release after merge)'
+    description: 'Whether to validate a planned version, prepare a PR branch, perform the full release flow, or create only the Git tag and GitHub release (auto-detect defaults to prepare for same-repo PRs, validate for fork PRs, and release after merge)'
     required: false
     default: 'auto-detect'
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29997,7 +29997,9 @@ async function run() {
     const newVersion = calculateVersion(latestVersion, releaseType, isPrerelease, inputs);
     core.info(`🆕 New version: ${newVersion}`);
 
-    handlePackageJson(inputs, newVersion);
+    if (executionMode !== 'release-only') {
+      handlePackageJson(inputs, newVersion);
+    }
 
     setReleaseOutputs({
       released: false,
@@ -30016,6 +30018,11 @@ async function run() {
     if (executionMode === 'prepare') {
       await preparePullRequestRelease(context, inputs, newVersion);
       core.info('✅ Pull request release preparation completed');
+      return;
+    }
+
+    if (executionMode === 'release-only') {
+      await createReleaseOnly(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
       return;
     }
 
@@ -30095,6 +30102,19 @@ async function createFinalRelease(octokit, context, inputs, latestVersion, newVe
 
   await createAndPushTag(newVersion, { pushBranch: shouldPushBranch });
 
+  await publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
+}
+
+async function createReleaseOnly(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease) {
+  core.info('🏷️ Release-only mode enabled. Skipping package.json handling, install, test, build, and branch commits.');
+
+  configureGit(inputs);
+
+  await createAndPushTag(newVersion, { pushBranch: false });
+  await publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
+}
+
+async function publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease) {
   const releaseNotes = generateReleaseNotes(latestVersion, newVersion, inputs);
 
   const release = await createRelease(octokit, context, {
@@ -30719,8 +30739,8 @@ function validateInputs(inputs) {
     errors.push('package-manager must be one of: npm, yarn, pnpm');
   }
 
-  if (!['auto-detect', 'validate', 'prepare', 'release'].includes(inputs.executionMode)) {
-    errors.push('execution-mode must be one of: auto-detect, validate, prepare, release');
+  if (!['auto-detect', 'validate', 'prepare', 'release', 'release-only'].includes(inputs.executionMode)) {
+    errors.push('execution-mode must be one of: auto-detect, validate, prepare, release, release-only');
   }
 
   if (inputs.packageJsonMode && !['update', 'verify', 'ignore'].includes(inputs.packageJsonMode)) {

--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,9 @@ async function run() {
     const newVersion = calculateVersion(latestVersion, releaseType, isPrerelease, inputs);
     core.info(`🆕 New version: ${newVersion}`);
 
-    handlePackageJson(inputs, newVersion);
+    if (executionMode !== 'release-only') {
+      handlePackageJson(inputs, newVersion);
+    }
 
     setReleaseOutputs({
       released: false,
@@ -89,6 +91,11 @@ async function run() {
     if (executionMode === 'prepare') {
       await preparePullRequestRelease(context, inputs, newVersion);
       core.info('✅ Pull request release preparation completed');
+      return;
+    }
+
+    if (executionMode === 'release-only') {
+      await createReleaseOnly(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
       return;
     }
 
@@ -168,6 +175,19 @@ async function createFinalRelease(octokit, context, inputs, latestVersion, newVe
 
   await createAndPushTag(newVersion, { pushBranch: shouldPushBranch });
 
+  await publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
+}
+
+async function createReleaseOnly(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease) {
+  core.info('🏷️ Release-only mode enabled. Skipping package.json handling, install, test, build, and branch commits.');
+
+  configureGit(inputs);
+
+  await createAndPushTag(newVersion, { pushBranch: false });
+  await publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease);
+}
+
+async function publishRelease(octokit, context, inputs, latestVersion, newVersion, releaseType, isPrerelease) {
   const releaseNotes = generateReleaseNotes(latestVersion, newVersion, inputs);
 
   const release = await createRelease(octokit, context, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,8 +116,8 @@ function validateInputs(inputs) {
     errors.push('package-manager must be one of: npm, yarn, pnpm');
   }
 
-  if (!['auto-detect', 'validate', 'prepare', 'release'].includes(inputs.executionMode)) {
-    errors.push('execution-mode must be one of: auto-detect, validate, prepare, release');
+  if (!['auto-detect', 'validate', 'prepare', 'release', 'release-only'].includes(inputs.executionMode)) {
+    errors.push('execution-mode must be one of: auto-detect, validate, prepare, release, release-only');
   }
 
   if (inputs.packageJsonMode && !['update', 'verify', 'ignore'].includes(inputs.packageJsonMode)) {


### PR DESCRIPTION
## What changed
This adds an explicit `release-only` execution mode.

## Why
There are cases where the merged PR workflow should create only the semantic version tag and GitHub release without touching `package.json` or running install, test, and build steps.

## Impact
`release-only` now skips package.json handling, dependency install, tests, builds, and branch commit/push steps.
It still creates the semantic version tag, the GitHub release, and the synced major version tag/release behavior when `base_release: true` is enabled.

## Validation
Updated the runtime logic, input validation, tests, docs, and committed `dist/index.js` bundle.
I could not run local Node/Jest/build checks in this environment because `node` and `npm` are not installed here.